### PR TITLE
Fix crate regex: allow digits

### DIFF
--- a/plugin/crates.vim
+++ b/plugin/crates.vim
@@ -151,7 +151,7 @@ function! g:CratesComplete(findstart, base)
     endwhile
     return start
   else
-    let crate = matchstr(getline('.'), '^[a-z\-_]\+')
+    let crate = matchstr(getline('.'), '^[a-z\-_0-9]\+')
     if !exists('b:crates')
       let b:crates = {}
     endif


### PR DESCRIPTION
Otherwise the plugin errors out on the package name `webkit2gtk`. It does try, but it attempts the name `webkit`, up to the digit, and that's not present in `b:crates`.

There might be different ways to fix this -- if the plugin knows the line is definitely a crate definition, maybe even getting anything non-whitespace up to the `=` might be fine. Happy to make changes to the PR.