### PR TITLE
Add option to always show newer caret version

### DIFF
--- a/plugin/crates.vim
+++ b/plugin/crates.vim
@@ -100,6 +100,9 @@ endfunction
 " Show latest version if it's outside of the given requirement.
 function! s:show(a, b) abort
   let has_wildcard = match(a:a, '\*') != -1
+  if !has_wildcard && get(g:, 'crates_always_show_newer_caret', 0)
+    return a:a !=# a:b
+  endif
   let a = split(a:a, '\.')
   let b = split(a:b, '\.')
   return has_wildcard ? s:show_wildcard(a, b) : s:show_caret(a, b)


### PR DESCRIPTION
Does what the title says.
For example, if a crate's version is set to `1.3.1` but latest is `1.4.0`, then latest would match the version requirement and thus won't be shown by default (current behavior), but with the flag `g:crates_always_show_newer_caret` set to 1, it will.