### PR TITLE
Reset nvim namespaces only in neovim

### DIFF
--- a/plugin/crates.vim
+++ b/plugin/crates.vim
@@ -254,8 +254,10 @@ function! crates#up() abort
     let line = substitute(line, '"\zs[0-9\.\*]\+\ze"', vers_latest, '')
   endif
   call setline(lnum, line)
-  call nvim_buf_clear_namespace(bufnr(''), nvim_create_namespace('crates'),
-        \ line('.')-1, line('.'))
+  if has('nvim')
+    call nvim_buf_clear_namespace(bufnr(''), nvim_create_namespace('crates'),
+          \ line('.')-1, line('.'))
+  endif
 endfunction
 
 function! s:setup() abort


### PR DESCRIPTION
Seems like these callbacks are used particularly for buffer highlights, so it should be fine to only call them on Neovim. Otherwise the function errors out on standard Vim.